### PR TITLE
Add psock device

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,6 @@ EXTRA_DIST = doxygen.cfg
 library_includedir=$(includedir)/usbg
 library_include_HEADERS = include/usbg/usbg.h include/usbg/usbg_version.h
 function_includedir=$(includedir)/usbg/function
-function_include_HEADERS = include/usbg/function/ffs.h include/usbg/function/loopback.h include/usbg/function/midi.h include/usbg/function/ms.h include/usbg/function/net.h include/usbg/function/phonet.h include/usbg/function/serial.h include/usbg/function/hid.h include/usbg/function/uac2.h
+function_include_HEADERS = include/usbg/function/ffs.h include/usbg/function/loopback.h include/usbg/function/midi.h include/usbg/function/ms.h include/usbg/function/net.h include/usbg/function/phonet.h include/usbg/function/serial.h include/usbg/function/hid.h include/usbg/function/uac2.h include/usbg/function/psock.h
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libusbgx.pc

--- a/include/usbg/function/psock.h
+++ b/include/usbg/function/psock.h
@@ -1,0 +1,29 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#ifndef USBG_FUNCTION_PSOCK__
+#define USBG_FUNCTION_PSOCK__
+
+#include <usbg/usbg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct usbg_f_psock;
+typedef struct usbg_f_serial usbg_f_psock;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USBG_FUNCTION_SERIAL__ */

--- a/include/usbg/usbg.h
+++ b/include/usbg/usbg.h
@@ -219,6 +219,7 @@ typedef enum
 	USBG_F_LOOPBACK,
 	USBG_F_HID,
 	USBG_F_UAC2,
+	USBG_F_PSOCK,
 	USBG_FUNCTION_TYPE_MAX,
 } usbg_function_type;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = std-options subdir-objects
 lib_LTLIBRARIES = libusbgx.la
-libusbgx_la_SOURCES = usbg.c usbg_error.c usbg_common.c function/ether.c function/ffs.c function/midi.c function/ms.c function/phonet.c function/serial.c function/loopback.c function/hid.c function/uac2.c
+libusbgx_la_SOURCES = usbg.c usbg_error.c usbg_common.c function/ether.c function/ffs.c function/midi.c function/ms.c function/phonet.c function/serial.c function/loopback.c function/hid.c function/uac2.c function/psock.c
 if TEST_GADGET_SCHEMES
 libusbgx_la_SOURCES += usbg_schemes_libconfig.c usbg_common_libconfig.c
 else

--- a/src/function/psock.c
+++ b/src/function/psock.c
@@ -1,0 +1,62 @@
+/*
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
+#include "usbg/usbg.h"
+#include "usbg/usbg_internal.h"
+//#include "usbg/function/psock.h"
+
+#ifdef HAS_GADGET_SCHEMES
+#include <libconfig.h>
+#endif
+
+struct usbg_f_psock {
+	struct usbg_function func;
+};
+
+GENERIC_ALLOC_INST(psock, struct usbg_f_psock, func);
+
+GENERIC_FREE_INST(psock, struct usbg_f_psock, func);
+
+static int psock_set_attrs(struct usbg_function *f, void *f_attrs)
+{
+	return USBG_SUCCESS;
+}
+
+static int psock_get_attrs(struct usbg_function *f, void *f_attrs)
+{
+	return USBG_SUCCESS;
+}
+
+static int psock_libconfig_import(struct usbg_function *f,
+				  config_setting_t *root)
+{
+	return USBG_SUCCESS;
+}
+
+static int psock_libconfig_export(struct usbg_function *f,
+				  config_setting_t *root)
+{
+	return USBG_SUCCESS;
+}
+
+#define PSOCK_FUNCTION_OPTS			\
+	.alloc_inst = psock_alloc_inst,		\
+	.free_inst = psock_free_inst,	        \
+	.set_attrs = psock_set_attrs,	        \
+	.get_attrs = psock_get_attrs,	        \
+	.export = psock_libconfig_export,	\
+	.import = psock_libconfig_import
+
+struct usbg_function_type usbg_f_type_psock = {
+	.name = "psock",
+	PSOCK_FUNCTION_OPTS,
+};

--- a/src/usbg.c
+++ b/src/usbg.c
@@ -52,6 +52,7 @@ extern struct usbg_function_type usbg_f_type_phonet;
 extern struct usbg_function_type usbg_f_type_loopback;
 extern struct usbg_function_type usbg_f_type_hid;
 extern struct usbg_function_type usbg_f_type_uac2;
+extern struct usbg_function_type usbg_f_type_psock;
 
 /**
  * @var function_types
@@ -73,6 +74,7 @@ struct usbg_function_type* function_types[] = {
 	[USBG_F_LOOPBACK] = &usbg_f_type_loopback,
 	[USBG_F_HID] = &usbg_f_type_hid,
 	[USBG_F_UAC2] = &usbg_f_type_uac2,
+	[USBG_F_PSOCK] = &usbg_f_type_psock,
 };
 
 ARRAY_SIZE_SENTINEL(function_types, USBG_FUNCTION_TYPE_MAX);


### PR DESCRIPTION
Adds a new device type for our psock driver, no options are currently passed. 